### PR TITLE
Handle short language header

### DIFF
--- a/src/hooks.server.js
+++ b/src/hooks.server.js
@@ -8,10 +8,10 @@ export const handle = async ({ event, resolve }) => {
 		const savedLocale = localeCookie.split('=')[1];
 		locale.set(savedLocale);
 	} else {
-		const lang = event.request.headers.get('accept-language')?.split(',')[0];
-		if (lang && lang.length == 2) {
-			locale.set(lang);
-		}
+               const lang = event.request.headers.get('accept-language')?.split(',')[0]?.slice(0,2);
+               if (lang) {
+                       locale.set(lang);
+               }
 	}
 
 	return resolve(event);


### PR DESCRIPTION
## Summary
- respect only the first two letters of `accept-language` header

## Testing
- `npm run lint` *(fails: Code style issues found in 13 files)*

------
https://chatgpt.com/codex/tasks/task_e_686662871740832383f7689057202828